### PR TITLE
Replace ua sniffing with feature detection

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -4,12 +4,11 @@ var debug = false;
 var isStatsOn = false;
 
 try {
-	var ua = navigator.userAgent.toLowerCase();
-	if(ua.search('chrome') < 0 && ua.search('safari') < 0) {
-		alert('This is an experiment that has only been tested in Chrome, Safari and Firefox 4Beta, and may not work in other browsers');
+	if(!window.Websocket) {
+		alert('This is an experiment that has only been tested in the latest versions of browsers that support WebSockets may not work in other browsers');
 	}
 } catch(err) {
-	alert('This is an experiment that has only been tested in Chrome, Safari and Firefox 4Beta, and may not work in other browsers');
+	alert('This is an experiment that has only been tested in the latest versions of browsers that support WebSockets may not work in other browsers');
 }
 
 var runLoop = function() {


### PR DESCRIPTION
Sniffing for Chrome or Safari in the UA string already fails in FF4beta and the latest Opera 10.70 desktop build, both of which support WebSockets. This change just does a simple feature detection before warning the user.
